### PR TITLE
Moved 'InstrumentFullName=' to OSC() SetDefaults

### DIFF
--- a/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
+++ b/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
@@ -443,7 +443,6 @@ namespace NinjaTrader.NinjaScript.Strategies
                         break;
                     case State.Configure:
                         ATSAlgoSystemState = AlgoSystemState.Starting;
-                        InstrumentFullName = this.Instrument.FullName;
 
                         break;
                     case State.Active:
@@ -459,6 +458,8 @@ namespace NinjaTrader.NinjaScript.Strategies
                             ATSAlgoSystemMode = AlgoSystemMode.Replay;
 
                         ATSAlgoSystemState = AlgoSystemState.DataLoaded;
+                        
+                       InstrumentFullName = this.Instrument.FullName;
 
                         break;
                     case State.Historical:


### PR DESCRIPTION
Executing Strategy Analyzer - Optimization on the 'ATSSampleMACrossOver' sample produced the following exception in the Log.   Moving 'InstrumentFullName = this.Instrument.FullName;' to OSC() State.DataLoaded cleared the exception.  

Exception in the Log: 'OnStateChange System.NullReferenceException: Object reference not set to an instance of an object.    at NinjaTrader.NinjaScript.Strategies.ATSQuadroStrategyBase.OnStateChange()'