### PR TITLE
Fix to actually call TradeManagement and reset flag

### DIFF
--- a/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
+++ b/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
@@ -612,7 +612,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                         if (ATSAlgoSystemState == AlgoSystemState.Transition)
                             ATSAlgoSystemState = AlgoSystemState.Realtime;
 
-                        // one time only, as we transition from historical to real-time - doesnt seem to work  for unmanaged mode
+                        // one time only, as we transition from historical to real-time - doesnt seem to work for unmanaged mode
                         // the work around was to use order names and reference them OnOrderUpdate
                         //https://ninjatrader.com/support/helpGuides/nt8/?getrealtimeorder.htm
 
@@ -3507,21 +3507,22 @@ namespace NinjaTrader.NinjaScript.Strategies
         }
         private void TradeManagementExecInternal(double lastPrice)
         {
-            //make sure something is not midflight suchj as order operations
+            //make sure something is not midflight such as order operations
             if (!IsTradeWorkFlowReady())
                 return;
-
             //use this to guard against multiple thread entry from OnMarket data and onBarUpdate
             if (isInTradeManagementProcessInternal)
                 return;
-
             lock (lockObjectTradeManInternal)
             {
                 if (isInTradeManagementProcessInternal)
                     return;
                 isInTradeManagementProcessInternal = true;
+            
+                TradeManagement(lastPrice);
+
+                isInTradeManagementProcessInternal = false;
             }
-            TradeManagement(lastPrice);
         }
         public virtual void TradeManagement(double lastPrice)
         {


### PR DESCRIPTION
Unless I'm missing something, `TradeManagement` callback was never actually being called in the Hybrid Demo or other Algos.

It looks to me like bits of the locking logic were removed or incomplete, as the `isInTradeManagementProcessInternal` flag was never actually cleared either.

This small fix appears to rectify that, I'm guessing this was the intent of the locking.

The second test inside the lock seems dubious, the exclusive lock should be sufficient, but I left it for now.
```
   if (isInTradeManagementProcessInternal)
                    return;
```