### PR TITLE
Fix Playback mode to follow trusted realtime codepaths for consistency

### DIFF
--- a/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
+++ b/ATSQuadroStrategyBase/NinjaTrader 8/bin/Custom/Strategies/AlgoSystemBase.cs
@@ -1775,11 +1775,11 @@ namespace NinjaTrader.NinjaScript.Strategies
                     return;
                 }
 
-                if (IsHistoricalTradeOrPlayBack || IsOrderCancelInspectEachOrDoBatchCancel)
+                if (IsOrderCancelInspectEachOrDoBatchCancel)
                 {
 
                     if (tracing)
-                        Print("CancelAllOrders() > IsHistOrPBack || IsCancelInspectEach");
+                        Print("CancelAllOrders() > IsCancelInspectEach");
 
                     //call cancel as orderstate is unreliable check for nulls
                     if (IsOrderActiveCanCancel(orderStop1)) CancelOrder(orderStop1);
@@ -2029,9 +2029,9 @@ namespace NinjaTrader.NinjaScript.Strategies
         {
             if (tracing) Print("SubmitSignalAction " + AlgoSignalActions.ToString() + " WF=" + this.TradeWorkFlow.ToString());
 
-            TEQ.Enqueue(new AlgoSignalActionMsq(AlgoSignalActions, IsHistoricalTradeOrPlayBack ? Time[0] : Now, signalLabel));
+            TEQ.Enqueue(new AlgoSignalActionMsq(AlgoSignalActions, Now, signalLabel));
             #region Signal Execution
-            if (IsHistoricalTradeOrPlayBack || !IsRealtimeTradingUseQueue)
+            if (!IsRealtimeTradingUseQueue)
             {
                 if (TEQ.Count > 0) ProcessTradeEventQueue(this);
             }
@@ -2224,7 +2224,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     //trade per direction test
                     if (Position.MarketPosition == MarketPosition.Long) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoLongValidationRejected);
 
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongCancelWorkingOrders;
                         goto case StrategyTradeWorkFlowState.GoLongCancelWorkingOrders;
@@ -2248,7 +2248,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoLongSubmitOrder);
                 case StrategyTradeWorkFlowState.GoLongCancelWorkingOrders:
 
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         CancelAllOrders();
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongClosePositions;
@@ -2290,7 +2290,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     break;
                 case StrategyTradeWorkFlowState.GoLongCancelWorkingOrdersConfirmed:
                     TradeWorkFlowOnMarketDataDisable();
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         if (Position.Quantity != 0)
                         {
@@ -2309,7 +2309,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.GoLongClosePositions:
                     if (Position.Quantity != 0)
                     {
-                        if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                        if (IsStrategyUnSafeMode)
                         {
                             TradeWorkFlow = StrategyTradeWorkFlowState.GoLongClosedPositionsPending;
                             PositionCloseInternal();
@@ -2366,7 +2366,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     TradeWorkFlowOnMarketDataDisable();
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoLongSubmitOrder);
                 case StrategyTradeWorkFlowState.GoLongSubmitOrder:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         if (PreTradeValidateCanEnterTrade(true))
                         {
@@ -2402,7 +2402,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
                     break;
                 case StrategyTradeWorkFlowState.GoLongValidationRejected:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode || !IsOnStrategyTradeWorkFlowStateEntryRejectionError) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
+                    if (IsStrategyUnSafeMode || !IsOnStrategyTradeWorkFlowStateEntryRejectionError) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.Error);
                 case StrategyTradeWorkFlowState.GoLongSubmitOrderPending:
                     //must catch nulls here in case the submit order was not placed and returned null
@@ -2432,7 +2432,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     if (SubmitProfitTargetWillOccur()) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoLongPlaceProfitTargets);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.GoLongPlaceStops:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongPlaceStopsPending;
                         SubmitStopLossInternal();
@@ -2454,7 +2454,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     break;
                 case StrategyTradeWorkFlowState.GoLongPlaceStopsPending:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongPlaceStopsConfirmed;
                         goto case StrategyTradeWorkFlowState.GoLongPlaceStopsConfirmed;
@@ -2487,7 +2487,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     if (SubmitProfitTargetWillOccur()) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoLongPlaceProfitTargets);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.GoLongPlaceProfitTargets:
-                    if (IsHistoricalTradeOrPlayBack || !IsSubmitTargetsAndConfirm)
+                    if (!IsSubmitTargetsAndConfirm)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongPlaceProfitTargetsPending;
                         SubmitProfitTargetInternal();
@@ -2511,7 +2511,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     break;
                 case StrategyTradeWorkFlowState.GoLongPlaceProfitTargetsPending:
-                    if (IsHistoricalTradeOrPlayBack || !IsSubmitTargetsAndConfirm)
+                    if (!IsSubmitTargetsAndConfirm)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoLongPlaceProfitTargetsConfirmed;
                         goto case StrategyTradeWorkFlowState.GoLongPlaceProfitTargetsConfirmed;
@@ -2542,7 +2542,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     //trade per direction test
                     if (Position.MarketPosition == MarketPosition.Short) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoShortValidationRejected);
 
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortCancelWorkingOrders;
                         goto case StrategyTradeWorkFlowState.GoShortCancelWorkingOrders;
@@ -2567,7 +2567,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoShortSubmitOrder);
 
                 case StrategyTradeWorkFlowState.GoShortCancelWorkingOrders:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         CancelAllOrders();
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortCancelWorkingOrdersConfirmed;
@@ -2607,7 +2607,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.GoShortCancelWorkingOrdersConfirmed:
 
                     TradeWorkFlowOnMarketDataDisable();
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         if (Position.Quantity != 0)
                         {
@@ -2627,7 +2627,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.GoShortClosePositions:
                     if (Position.Quantity != 0)
                     {
-                        if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                        if (IsStrategyUnSafeMode)
                         {
                             TradeWorkFlow = StrategyTradeWorkFlowState.GoShortClosedPositionsPending;
                             PositionCloseInternal();
@@ -2682,7 +2682,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     TradeWorkFlowOnMarketDataDisable();
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoShortSubmitOrder);
                 case StrategyTradeWorkFlowState.GoShortSubmitOrder:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         if (PreTradeValidateCanEnterTrade(false))
                         {
@@ -2722,7 +2722,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
                     break;
                 case StrategyTradeWorkFlowState.GoShortValidationRejected:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode || !IsOnStrategyTradeWorkFlowStateEntryRejectionError) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
+                    if (IsStrategyUnSafeMode || !IsOnStrategyTradeWorkFlowStateEntryRejectionError) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.Error);
                 case StrategyTradeWorkFlowState.GoShortSubmitOrderPending:
                     //must catch nulls here in case the submit order was not placed and returned null
@@ -2752,7 +2752,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     if (SubmitProfitTargetWillOccur()) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoShortPlaceProfitTargets);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.GoShortPlaceStops:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortPlaceStopsPending;
                         SubmitStopLossInternal();
@@ -2775,7 +2775,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     break;
                 case StrategyTradeWorkFlowState.GoShortPlaceStopsPending:
 
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortPlaceStopsConfirmed;
                         goto case StrategyTradeWorkFlowState.GoShortPlaceStopsConfirmed;
@@ -2805,7 +2805,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     if (SubmitProfitTargetWillOccur()) return ProcessWorkFlow(StrategyTradeWorkFlowState.GoShortPlaceProfitTargets);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.GoShortPlaceProfitTargets:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortPlaceProfitTargetsPending;
                         SubmitProfitTargetInternal();
@@ -2830,7 +2830,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     break;
                 case StrategyTradeWorkFlowState.GoShortPlaceProfitTargetsPending:
-                    if (IsHistoricalTradeOrPlayBack || !IsSubmitTargetsAndConfirm)
+                    if (!IsSubmitTargetsAndConfirm)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoShortPlaceProfitTargetsConfirmed;
                         goto case StrategyTradeWorkFlowState.GoShortPlaceProfitTargetsConfirmed;
@@ -2860,7 +2860,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 //Begin GoOCO
                 case StrategyTradeWorkFlowState.GoOCOLongShort:
                     //trade per direction test
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoOCOLongShortCancelWorkingOrders;
                         goto case StrategyTradeWorkFlowState.GoOCOLongShortCancelWorkingOrders;
@@ -2884,7 +2884,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoOCOLongShortSubmitOrder);
 
                 case StrategyTradeWorkFlowState.GoOCOLongShortCancelWorkingOrders:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         CancelAllOrders();
                         TradeWorkFlow = StrategyTradeWorkFlowState.GoOCOLongShortCancelWorkingOrdersConfirmed;
@@ -2928,7 +2928,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.GoOCOLongShortClosePositions:
                     if (Position.Quantity != 0)
                     {
-                        if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                        if (IsStrategyUnSafeMode)
                         {
                             TradeWorkFlow = StrategyTradeWorkFlowState.GoOCOLongShortClosedPositionsPending;
                             PositionCloseInternal();
@@ -2983,7 +2983,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     TradeWorkFlowOnMarketDataDisable();
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.GoOCOLongShortSubmitOrder);
                 case StrategyTradeWorkFlowState.GoOCOLongShortSubmitOrder:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         if (PreTradeValidateCanEnterTradeOCO())
                         {
@@ -3026,7 +3026,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
                     break;
                 case StrategyTradeWorkFlowState.GoOCOLongShortValidationRejected:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
+                    if (IsStrategyUnSafeMode) return ProcessWorkFlow(StrategyTradeWorkFlowState.Waiting);
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.Error);
                 case StrategyTradeWorkFlowState.GoOCOLongShortSubmitOrderPending:
                     //must catch nulls here in case the submit order was not placed and returned null
@@ -3057,13 +3057,13 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.ExitTrade:
                     //orders to cancel test
 
-                    if (IsHistoricalTradeOrPlayBack || IsOrdersAnyActiveExist()) return ProcessWorkFlow(StrategyTradeWorkFlowState.ExitTradeCancelWorkingOrders);
+                    if (IsOrdersAnyActiveExist()) return ProcessWorkFlow(StrategyTradeWorkFlowState.ExitTradeCancelWorkingOrders);
                     //position to close test
                     if (Position.Quantity != 0) return ProcessWorkFlow(StrategyTradeWorkFlowState.ExitTradeClosePositions);
                     //nothing to do
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.ExitTradeCancelWorkingOrders:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
 
                         CancelAllOrders();
@@ -3087,7 +3087,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     break;
                 case StrategyTradeWorkFlowState.ExitTradeCancelWorkingOrderPending:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                         return ProcessWorkFlow(StrategyTradeWorkFlowState.ExitTradeCancelWorkingOrderConfirmed);
 
                     if (IsOrdersAnyActiveExist())
@@ -3110,7 +3110,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.ExitTradeClosePositions:
                     if (Position.Quantity != 0)
                     {
-                        if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                        if (IsStrategyUnSafeMode)
                         {
                             TradeWorkFlow = StrategyTradeWorkFlowState.ExitTradeClosePositionsPending;
                             PositionCloseInternal();
@@ -3137,7 +3137,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     break;
                 case StrategyTradeWorkFlowState.ExitTradeClosePositionsPending:
                     //execution event or realtime event or timer moves event on
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode) break;
+                    if (IsStrategyUnSafeMode) break;
                     if (Position.Quantity != 0)
                     {
                         TradeWorkFlowOnMarketDataEnable();
@@ -3152,7 +3152,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     break;
                 case StrategyTradeWorkFlowState.ExitTradeClosePositionsConfirmed:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                         return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
 
                     TradeWorkFlowOnMarketDataDisable();
@@ -3182,7 +3182,7 @@ namespace NinjaTrader.NinjaScript.Strategies
                 case StrategyTradeWorkFlowState.ErrorTimeOut:
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.Error);
                 case StrategyTradeWorkFlowState.Error:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         CancelAllOrders();
                         //Assume all cancelled and move workflow onwards
@@ -3212,7 +3212,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
                     break;
                 case StrategyTradeWorkFlowState.ErrorFlattenAll:
-                    if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+                    if (IsStrategyUnSafeMode)
                     {
                         PositionCloseInternal(false);
                         return ProcessWorkFlow(StrategyTradeWorkFlowState.ErrorFlattenAllConfirmed);
@@ -3288,14 +3288,14 @@ namespace NinjaTrader.NinjaScript.Strategies
                     }
                     return ProcessWorkFlow(StrategyTradeWorkFlowState.CycleComplete);
                 case StrategyTradeWorkFlowState.ExitOnCloseOrderPending:
-                    if (IsHistoricalTradeOrPlayBack) break;
+                    if (IsHistorical) break;
 
                     TradeWorkFlow = StrategyTradeWorkFlowState.ExitOnCloseWaitingConfirmation;
                     TradeWorkFlowOnMarketDataEnable();
 
                     break;
                 case StrategyTradeWorkFlowState.ExitOnCloseWaitingConfirmation:
-                    if (IsHistoricalTradeOrPlayBack) break;
+                    if (IsHistorical) break;
 
                     if (IsOrdersAnyActiveExist() || Position.MarketPosition != MarketPosition.Flat)
                     {
@@ -3374,7 +3374,7 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (tracing)
                 Print("TradeWorkFlowErrorProcess() > forceImmediate " + forceImmediate.ToString());
 
-            if (IsHistoricalTradeOrPlayBack || forceImmediate)
+            if (forceImmediate)
                 ProcessWorkFlow(TradeWorkFlow);
 
             //deferred execution
@@ -3592,7 +3592,7 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (tracing)
                 Print("submitStopLossInternal(" + orderEntry.ToString() + ")");
 
-            if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+            if (IsStrategyUnSafeMode)
             {
                 SubmitStopLoss(this.orderEntry);
                 return;
@@ -3634,10 +3634,7 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (tracing)
                 Print("submitProfitTargetInternal(orderEntry " + orderEntry != null ? orderEntry.ToString() : "null" + ")");
 
-
-
-
-            if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
+            if (IsStrategyUnSafeMode)
             {
                 SubmitProfitTarget(this.orderEntry, this.oCOId);
                 return;
@@ -4786,7 +4783,7 @@ namespace NinjaTrader.NinjaScript.Strategies
 
         [Browsable(false)]
         [XmlIgnore()]
-        public bool IsHistoricalTradeOrPlayBack { get { return State == State.Historical || ATSAlgoSystemState == AlgoSystemState.HisTradeRT || IsPlayBack; } }
+        public bool IsHistoricalTradeOrPlayBack { get { return IsHistorical || IsPlayBack; } }
 
 
         [Browsable(false)]


### PR DESCRIPTION
This change may certainly need some review, as I do not have reference/understanding as to why this alternative code path was chosen for Playback mode.  

```
 if (IsHistoricalTradeOrPlayBack || IsStrategyUnSafeMode)
```

I found a lot of instances where Playback was following the "IsStrategyUnsafeMode"; While not clear on the purpose, With all the warnings about not using UnsafeMode unless you fully understood the code, I was surprised this was being used in Playback by default.  I would like to be able to backtest with confidence that close to the same code paths are used in live.

I think I caught the cases where a Historical (but not Playback) conditional is needed, and adjusted accordingly.

btw, One side effect that actually caused me to dig deeper into this was that the `OrdersStopLoss` list was never being populated, which prevent the more elegant looping use case in the Strategy...  it doesn't populate in the Unsafe codepath.
```
foreach (Order o in OrdersStopLoss.Where(o => IsOrderIsActive(o)).ToList<Order>()) {
}
```

I have been testing with this update for a couple of days, and have not run into any issues in playback or live modes.  

Oh, and this addresses the "Entry Order Timeout" I discovered in #88, now my entry orders don't timeout.  (Still looking for the OrderTTL references you mentioned).

Note that this PR also includes the Now changes in #91 so that you can see it as a fully working branch.

Closes #88